### PR TITLE
Removes typedi and reflect-metadata as dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ This project is currently a work in progress and contributors are welcome! 👋
   - SS_API_SECRET (your Shipstation API secret)
 
 ```js
-import shipstation from 'shipstation-node';
+import ShipStation from 'shipstation-node'
+
+// Create instance
+const shipstation = new ShipStation()
 
 // Get all orders
 const orders = await shipstation.orders.getAll()

--- a/dist/index.js
+++ b/dist/index.js
@@ -10,7 +10,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-require("reflect-metadata");
 var Models = __importStar(require("./models"));
 exports.Models = Models;
 var Carriers_1 = require("./resources/Carriers");
@@ -20,22 +19,17 @@ var Shipments_1 = require("./resources/Shipments");
 var Stores_1 = require("./resources/Stores");
 var Webhooks_1 = require("./resources/Webhooks");
 var shipstation_1 = __importDefault(require("./shipstation"));
-var shipstation = function () {
-    var ss = new shipstation_1.default();
-    var orders = new Orders_1.Orders(ss);
-    var carriers = new Carriers_1.Carriers(ss);
-    var fulfillments = new Fulfillments_1.Fulfillments(ss);
-    var stores = new Stores_1.Stores(ss);
-    var shipments = new Shipments_1.Shipments(ss);
-    var webhooks = new Webhooks_1.Webhooks(ss);
-    return {
-        carriers: carriers,
-        fulfillments: fulfillments,
-        orders: orders,
-        stores: stores,
-        shipments: shipments,
-        webhooks: webhooks,
-        request: ss.request
-    };
-};
-exports.default = shipstation();
+var ShipStationAPI = (function () {
+    function ShipStationAPI() {
+        this.ss = new shipstation_1.default();
+        this.orders = new Orders_1.Orders(this.ss);
+        this.carriers = new Carriers_1.Carriers(this.ss);
+        this.fulfillments = new Fulfillments_1.Fulfillments(this.ss);
+        this.stores = new Stores_1.Stores(this.ss);
+        this.shipments = new Shipments_1.Shipments(this.ss);
+        this.webhooks = new Webhooks_1.Webhooks(this.ss);
+        this.request = this.ss.request;
+    }
+    return ShipStationAPI;
+}());
+exports.default = ShipStationAPI;

--- a/dist/resources/Carriers.js
+++ b/dist/resources/Carriers.js
@@ -12,15 +12,6 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -57,16 +48,8 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var typedi_1 = require("typedi");
-var shipstation_1 = __importStar(require("../shipstation"));
+var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Carriers = (function (_super) {
     __extends(Carriers, _super);
@@ -93,10 +76,6 @@ var Carriers = (function (_super) {
             });
         });
     };
-    Carriers = __decorate([
-        typedi_1.Service(),
-        __metadata("design:paramtypes", [shipstation_1.default])
-    ], Carriers);
     return Carriers;
 }(Base_1.BaseResource));
 exports.Carriers = Carriers;

--- a/dist/resources/Fulfillments.js
+++ b/dist/resources/Fulfillments.js
@@ -12,15 +12,6 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -57,16 +48,8 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var typedi_1 = require("typedi");
-var shipstation_1 = __importStar(require("../shipstation"));
+var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Fulfillments = (function (_super) {
     __extends(Fulfillments, _super);
@@ -93,10 +76,6 @@ var Fulfillments = (function (_super) {
             });
         });
     };
-    Fulfillments = __decorate([
-        typedi_1.Service(),
-        __metadata("design:paramtypes", [shipstation_1.default])
-    ], Fulfillments);
     return Fulfillments;
 }(Base_1.BaseResource));
 exports.Fulfillments = Fulfillments;

--- a/dist/resources/Orders.js
+++ b/dist/resources/Orders.js
@@ -12,15 +12,6 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -57,16 +48,8 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var typedi_1 = require("typedi");
-var shipstation_1 = __importStar(require("../shipstation"));
+var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Orders = (function (_super) {
     __extends(Orders, _super);
@@ -131,10 +114,6 @@ var Orders = (function (_super) {
             });
         });
     };
-    Orders = __decorate([
-        typedi_1.Service(),
-        __metadata("design:paramtypes", [shipstation_1.default])
-    ], Orders);
     return Orders;
 }(Base_1.BaseResource));
 exports.Orders = Orders;

--- a/dist/resources/Shipments.js
+++ b/dist/resources/Shipments.js
@@ -12,15 +12,6 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -57,16 +48,8 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var typedi_1 = require("typedi");
-var shipstation_1 = __importStar(require("../shipstation"));
+var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Shipments = (function (_super) {
     __extends(Shipments, _super);
@@ -94,10 +77,6 @@ var Shipments = (function (_super) {
             });
         });
     };
-    Shipments = __decorate([
-        typedi_1.Service(),
-        __metadata("design:paramtypes", [shipstation_1.default])
-    ], Shipments);
     return Shipments;
 }(Base_1.BaseResource));
 exports.Shipments = Shipments;

--- a/dist/resources/Stores.js
+++ b/dist/resources/Stores.js
@@ -12,15 +12,6 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -57,16 +48,8 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var typedi_1 = require("typedi");
-var shipstation_1 = __importStar(require("../shipstation"));
+var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Stores = (function (_super) {
     __extends(Stores, _super);
@@ -105,10 +88,6 @@ var Stores = (function (_super) {
             });
         });
     };
-    Stores = __decorate([
-        typedi_1.Service(),
-        __metadata("design:paramtypes", [shipstation_1.default])
-    ], Stores);
     return Stores;
 }(Base_1.BaseResource));
 exports.Stores = Stores;

--- a/dist/resources/Webhooks.js
+++ b/dist/resources/Webhooks.js
@@ -12,15 +12,6 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -57,16 +48,8 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var typedi_1 = require("typedi");
-var shipstation_1 = __importStar(require("../shipstation"));
+var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Webhooks = (function (_super) {
     __extends(Webhooks, _super);
@@ -130,10 +113,6 @@ var Webhooks = (function (_super) {
             });
         });
     };
-    Webhooks = __decorate([
-        typedi_1.Service(),
-        __metadata("design:paramtypes", [shipstation_1.default])
-    ], Webhooks);
     return Webhooks;
 }(Base_1.BaseResource));
 exports.Webhooks = Webhooks;

--- a/dist/shipstation.js
+++ b/dist/shipstation.js
@@ -1,19 +1,9 @@
 "use strict";
-var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
-    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
-    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
-    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
-    return c > 3 && r && Object.defineProperty(target, key, r), r;
-};
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 var axios_1 = __importDefault(require("axios"));
-var typedi_1 = require("typedi");
 var base64 = require('base-64');
 var stopcock = require('stopcock');
 var rateLimitOpts = {
@@ -50,10 +40,6 @@ var Shipstation = (function () {
         this.authorizationToken = base64.encode(process.env.SS_API_KEY + ":" + process.env.SS_API_SECRET);
         this.request = stopcock(this.request, rateLimitOpts);
     }
-    Shipstation = __decorate([
-        typedi_1.Service(),
-        __metadata("design:paramtypes", [])
-    ], Shipstation);
     return Shipstation;
 }());
 exports.default = Shipstation;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
       "dev": true,
       "requires": {
-        "axios": "0.19.0"
+        "axios": "*"
       }
     },
     "@types/node": {
@@ -31,7 +31,7 @@
       "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
         "follow-redirects": "1.5.10",
-        "is-buffer": "2.0.4"
+        "is-buffer": "^2.0.2"
       }
     },
     "base-64": {
@@ -64,7 +64,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "=3.1.0"
       }
     },
     "is-buffer": {
@@ -106,11 +106,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "reflect-metadata": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
-      "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -123,8 +118,8 @@
       "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "stopcock": {
@@ -138,20 +133,15 @@
       "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "buffer-from": "1.1.1",
-        "diff": "3.5.0",
-        "make-error": "1.3.5",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.5.9",
-        "yn": "2.0.0"
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^2.0.0"
       }
-    },
-    "typedi": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/typedi/-/typedi-0.8.0.tgz",
-      "integrity": "sha512-/c7Bxnm6eh5kXx2I+mTuO+2OvoWni5+rXA3PhXwVWCtJRYmz3hMok5s1AKLzoDvNAZqj/Q/acGstN0ri5aQoOA=="
     },
     "typescript": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -6,20 +6,27 @@
   "scripts": {
     "build": "tsc"
   },
-  "author": "Keenan Jaenicke<kjaenick@gmail.com>",
+  "author": "Keenan Jaenicke <kjaenick@gmail.com>",
   "license": "MIT",
   "types": "typings/index.d.ts",
   "dependencies": {
     "axios": "^0.19.0",
     "base-64": "^0.1.0",
-    "reflect-metadata": "^0.1.12",
     "stopcock": "^1.0.0",
-    "typedi": "^0.8.0",
     "typescript": "^3.6.4"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",
     "@types/node": "^12.11.5",
     "ts-node": "^7.0.1"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kjaenicke/shipstation-node.git"
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/kjaenicke/shipstation-node/issues"
+  },
+  "homepage": "https://github.com/kjaenicke/shipstation-node#readme"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata'
+import { AxiosResponse } from 'axios'
 
 import * as Models from './models'
 import { Carriers } from './resources/Carriers'
@@ -7,28 +7,32 @@ import { Orders } from './resources/Orders'
 import { Shipments } from './resources/Shipments'
 import { Stores } from './resources/Stores'
 import { Webhooks } from './resources/Webhooks'
-import Shipstation from './shipstation'
+import Shipstation, { IShipstationRequestOptions } from './shipstation'
 
-const shipstation = () => {
-  const ss = new Shipstation()
+export default class ShipStationAPI {
+  private ss: Shipstation
 
-  const orders = new Orders(ss)
-  const carriers = new Carriers(ss)
-  const fulfillments = new Fulfillments(ss)
-  const stores = new Stores(ss)
-  const shipments = new Shipments(ss)
-  const webhooks = new Webhooks(ss)
+  public orders: Orders
+  public carriers: Carriers
+  public fulfillments: Fulfillments
+  public stores: Stores
+  public shipments: Shipments
+  public webhooks: Webhooks
+  public request: (
+    args: IShipstationRequestOptions
+  ) => Promise<AxiosResponse<any>>
 
-  return {
-    carriers,
-    fulfillments,
-    orders,
-    stores,
-    shipments,
-    webhooks,
-    request: ss.request
+  constructor() {
+    this.ss = new Shipstation()
+
+    this.orders = new Orders(this.ss)
+    this.carriers = new Carriers(this.ss)
+    this.fulfillments = new Fulfillments(this.ss)
+    this.stores = new Stores(this.ss)
+    this.shipments = new Shipments(this.ss)
+    this.webhooks = new Webhooks(this.ss)
+    this.request = this.ss.request
   }
 }
 
-export default shipstation()
 export { Models }

--- a/src/resources/Carriers.ts
+++ b/src/resources/Carriers.ts
@@ -1,9 +1,7 @@
-import { Service } from 'typedi'
 import { ICarrier } from '../models'
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
 
-@Service()
 export class Carriers extends BaseResource<ICarrier> {
   constructor(protected shipstation: Shipstation) {
     super(shipstation, 'carriers')

--- a/src/resources/Fulfillments.ts
+++ b/src/resources/Fulfillments.ts
@@ -1,9 +1,7 @@
-import { Service } from 'typedi'
 import { IFulfillment, IFulfillmentPaginationResult } from '../models'
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
 
-@Service()
 export class Fulfillments extends BaseResource<IFulfillment> {
   constructor(protected shipstation: Shipstation) {
     super(shipstation, 'fulfillments')

--- a/src/resources/Orders.ts
+++ b/src/resources/Orders.ts
@@ -1,4 +1,3 @@
-import { Service } from 'typedi'
 import {
   ICreateOrUpdateOrder,
   ICreateOrUpdateOrderBulkResponse,
@@ -8,7 +7,6 @@ import {
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
 
-@Service()
 export class Orders extends BaseResource<IOrder> {
   constructor(protected shipstation: Shipstation) {
     super(shipstation, 'orders')

--- a/src/resources/Shipments.ts
+++ b/src/resources/Shipments.ts
@@ -1,9 +1,7 @@
-import { Service } from 'typedi'
 import { IShipment } from '../models'
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
 
-@Service()
 export class Shipments extends BaseResource<IShipment> {
   constructor(protected shipstation: Shipstation) {
     super(shipstation, 'shipments')

--- a/src/resources/Stores.ts
+++ b/src/resources/Stores.ts
@@ -1,4 +1,3 @@
-import { Service } from 'typedi'
 import { IStore } from '../models'
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
@@ -8,7 +7,6 @@ export interface IGetAllStoresOptions {
   marketplaceId?: number
 }
 
-@Service()
 export class Stores extends BaseResource<IStore> {
   constructor(protected shipstation: Shipstation) {
     super(shipstation, 'stores')

--- a/src/resources/Webhooks.ts
+++ b/src/resources/Webhooks.ts
@@ -1,4 +1,3 @@
-import { Service } from 'typedi'
 import {
   ISubscribeToWebhookOpts,
   ISubscriptionResponse,
@@ -8,7 +7,6 @@ import {
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
 
-@Service()
 export class Webhooks extends BaseResource<IWebhook> {
   constructor(protected shipstation: Shipstation) {
     super(shipstation, 'webhooks')

--- a/src/shipstation.ts
+++ b/src/shipstation.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosRequestConfig } from 'axios'
-import { Service } from 'typedi'
 
 // tslint:disable-next-line:no-var-requires
 const base64 = require('base-64')
@@ -24,7 +23,6 @@ export interface IShipstationRequestOptions {
   data?: any
 }
 
-@Service()
 export default class Shipstation {
   public authorizationToken: string
   private baseUrl: string = 'https://ssapi.shipstation.com/'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata';
+import { AxiosResponse } from 'axios';
 import * as Models from './models';
 import { Carriers } from './resources/Carriers';
 import { Fulfillments } from './resources/Fulfillments';
@@ -6,14 +6,16 @@ import { Orders } from './resources/Orders';
 import { Shipments } from './resources/Shipments';
 import { Stores } from './resources/Stores';
 import { Webhooks } from './resources/Webhooks';
-declare const _default: {
+import { IShipstationRequestOptions } from './shipstation';
+export default class ShipStationAPI {
+    private ss;
+    orders: Orders;
     carriers: Carriers;
     fulfillments: Fulfillments;
-    orders: Orders;
     stores: Stores;
     shipments: Shipments;
     webhooks: Webhooks;
-    request: ({ url, method, useBaseUrl, data }: import("./shipstation").IShipstationRequestOptions) => Promise<import("axios").AxiosResponse<any>>;
-};
-export default _default;
+    request: (args: IShipstationRequestOptions) => Promise<AxiosResponse<any>>;
+    constructor();
+}
 export { Models };


### PR DESCRIPTION
As pointed out in #2, typedi and reflect-metadata aren't need in the project. This PR removes them.  The default export is also updated to be a class with updated instructions listed in readme.