### PR TITLE
Added support for lookup params on the getAll methods

### DIFF
--- a/src/resources/Fulfillments.ts
+++ b/src/resources/Fulfillments.ts
@@ -7,8 +7,10 @@ export class Fulfillments extends BaseResource<IFulfillment> {
     super(shipstation, 'fulfillments')
   }
 
-  public async getAll(): Promise<IFulfillmentPaginationResult> {
-    const url = this.baseUrl
+  public async getAll(opts?: object): Promise<IFulfillmentPaginationResult> {
+    const query = this.buildQueryStringFromParams(opts)
+    const url = this.baseUrl + query
+    
     const response = await this.shipstation.request({
       url,
       method: RequestMethod.GET

--- a/src/resources/Orders.ts
+++ b/src/resources/Orders.ts
@@ -12,8 +12,10 @@ export class Orders extends BaseResource<IOrder> {
     super(shipstation, 'orders')
   }
 
-  public async getAll(): Promise<IOrderPaginationResult> {
-    const url = this.baseUrl
+  public async getAll(opts?: object): Promise<IOrderPaginationResult> {
+    const query = this.buildQueryStringFromParams(opts)
+    const url = this.baseUrl + query
+    
     const response = await this.shipstation.request({
       url,
       method: RequestMethod.GET

--- a/typings/resources/Fulfillments.d.ts
+++ b/typings/resources/Fulfillments.d.ts
@@ -4,5 +4,5 @@ import { BaseResource } from './Base';
 export declare class Fulfillments extends BaseResource<IFulfillment> {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(): Promise<IFulfillmentPaginationResult>;
+    getAll(opts?: object): Promise<IFulfillmentPaginationResult>;
 }

--- a/typings/resources/Orders.d.ts
+++ b/typings/resources/Orders.d.ts
@@ -4,7 +4,7 @@ import { BaseResource } from './Base';
 export declare class Orders extends BaseResource<IOrder> {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(): Promise<IOrderPaginationResult>;
+    getAll(opts?: object): Promise<IOrderPaginationResult>;
     createOrUpdate(data: ICreateOrUpdateOrder): Promise<IOrder>;
     createOrUpdateBulk(data: ICreateOrUpdateOrder[]): Promise<ICreateOrUpdateOrderBulkResponse>;
 }


### PR DESCRIPTION
The Orders and Fulfillments resources don't currently support query string params like Shipments do.  

Note: If you'd prefer, I'm willing (and would prefer) to build out the options interface similar to how it works in Stores but I don't have a good feel for how often those change on ShipStation's side or why Shipments is constructed differently.