### PR TITLE
Make WeightUnits optional

### DIFF
--- a/src/models/Weight.ts
+++ b/src/models/Weight.ts
@@ -3,5 +3,5 @@ export type Unit = 'pounds' | 'ounces' | 'grams'
 export interface IWeight {
   value: number
   units: Unit
-  WeightUnits: number
+  WeightUnits?: number
 }

--- a/typings/models/Weight.d.ts
+++ b/typings/models/Weight.d.ts
@@ -2,5 +2,5 @@ export declare type Unit = 'pounds' | 'ounces' | 'grams';
 export interface IWeight {
     value: number;
     units: Unit;
-    WeightUnits: number;
+    WeightUnits?: number;
 }


### PR DESCRIPTION
The `WeightUnits` property of `IWeight` is read-only. Making this optional to allow for creating weights in orders and order items using only `value` and `units`.

see https://www.shipstation.com/docs/api/models/weight/