### PR TITLE
Added Shipping Label Creation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,12 +1,25 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.RequestMethod = exports.Models = void 0;
 var Models = __importStar(require("./models"));
 exports.Models = Models;
 var Carriers_1 = require("./resources/Carriers");
@@ -17,7 +30,7 @@ var Stores_1 = require("./resources/Stores");
 var Warehouses_1 = require("./resources/Warehouses");
 var Webhooks_1 = require("./resources/Webhooks");
 var shipstation_1 = __importStar(require("./shipstation"));
-exports.RequestMethod = shipstation_1.RequestMethod;
+Object.defineProperty(exports, "RequestMethod", { enumerable: true, get: function () { return shipstation_1.RequestMethod; } });
 var ShipStationAPI = (function () {
     function ShipStationAPI() {
         this.ss = new shipstation_1.default();

--- a/dist/models/index.js
+++ b/dist/models/index.js
@@ -1,2 +1,28 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
 Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./Address"), exports);
+__exportStar(require("./AdvancedOptions"), exports);
+__exportStar(require("./Carrier"), exports);
+__exportStar(require("./Dimensions"), exports);
+__exportStar(require("./Fulfillment"), exports);
+__exportStar(require("./InsuranceOptions"), exports);
+__exportStar(require("./InternationalOptions"), exports);
+__exportStar(require("./Order"), exports);
+__exportStar(require("./Pagination"), exports);
+__exportStar(require("./Shipment"), exports);
+__exportStar(require("./ShippingRate"), exports);
+__exportStar(require("./ShippingRateOptions"), exports);
+__exportStar(require("./Store"), exports);
+__exportStar(require("./Warehouse"), exports);
+__exportStar(require("./Webhook"), exports);
+__exportStar(require("./Weight"), exports);

--- a/dist/resources/Base.js
+++ b/dist/resources/Base.js
@@ -36,6 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.BaseResource = void 0;
 var shipstation_1 = require("../shipstation");
 var BaseResource = (function () {
     function BaseResource(shipstation, baseUrl) {

--- a/dist/resources/Carriers.js
+++ b/dist/resources/Carriers.js
@@ -3,7 +3,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Carriers = void 0;
 var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Carriers = (function (_super) {

--- a/dist/resources/Fulfillments.js
+++ b/dist/resources/Fulfillments.js
@@ -3,7 +3,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Fulfillments = void 0;
 var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Fulfillments = (function (_super) {

--- a/dist/resources/Orders.js
+++ b/dist/resources/Orders.js
@@ -3,7 +3,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Orders = void 0;
 var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Orders = (function (_super) {
@@ -103,6 +104,25 @@ var Orders = (function (_super) {
                 switch (_a.label) {
                     case 0:
                         url = this.baseUrl + "/createorders";
+                        return [4, this.shipstation.request({
+                                url: url,
+                                method: shipstation_1.RequestMethod.POST,
+                                data: data
+                            })];
+                    case 1:
+                        response = _a.sent();
+                        return [2, response.data];
+                }
+            });
+        });
+    };
+    Orders.prototype.createLabel = function (data) {
+        return __awaiter(this, void 0, void 0, function () {
+            var url, response;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        url = this.baseUrl + "/createlabelfororder";
                         return [4, this.shipstation.request({
                                 url: url,
                                 method: shipstation_1.RequestMethod.POST,

--- a/dist/resources/Shipments.js
+++ b/dist/resources/Shipments.js
@@ -3,7 +3,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Shipments = void 0;
 var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Shipments = (function (_super) {

--- a/dist/resources/Stores.js
+++ b/dist/resources/Stores.js
@@ -3,7 +3,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Stores = void 0;
 var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Stores = (function (_super) {

--- a/dist/resources/Warehouses.js
+++ b/dist/resources/Warehouses.js
@@ -3,7 +3,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Warehouses = void 0;
 var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Warehouses = (function (_super) {

--- a/dist/resources/Webhooks.js
+++ b/dist/resources/Webhooks.js
@@ -3,7 +3,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -49,6 +49,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Webhooks = void 0;
 var shipstation_1 = require("../shipstation");
 var Base_1 = require("./Base");
 var Webhooks = (function (_super) {

--- a/dist/shipstation.js
+++ b/dist/shipstation.js
@@ -3,6 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.RequestMethod = void 0;
 var axios_1 = __importDefault(require("axios"));
 var base64 = require('base-64');
 var stopcock = require('stopcock');

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -112,6 +112,20 @@ export interface IOrderItem {
   modifyDate: string
 }
 
+export interface ICreateLabel {
+  orderId: number
+  carrierCode?: string
+  serviceCode?: string
+  confirmation?: string
+  shipDate: string
+  weight?: IWeight
+  dimensions?: IDimensions
+  insuranceOptions?: IInsuranceOptions
+  internationalOptions?: IInternationalOptions
+  advancedOptions?: IAdvancedOptions
+  testLabel: boolean
+}
+
 export interface IItemOption {
   name: string
   value: string
@@ -132,4 +146,13 @@ interface IBulkCreateOrUpdateOrderResponse {
 export interface ICreateOrUpdateOrderBulkResponse {
   results: IBulkCreateOrUpdateOrderResponse[]
   hasErrors: boolean
+}
+
+export interface ICreateLabelResponse {
+  shipmentId: number
+  shipmentCost: number
+  insuranceCost: number
+  trackingNumber: string
+  labelData: string
+  formData?: string
 }

--- a/src/resources/Orders.ts
+++ b/src/resources/Orders.ts
@@ -2,7 +2,9 @@ import {
   ICreateOrUpdateOrder,
   ICreateOrUpdateOrderBulkResponse,
   IOrder,
-  IOrderPaginationResult
+  IOrderPaginationResult,
+  ICreateLabel,
+  ICreateLabelResponse
 } from '../models'
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
@@ -15,7 +17,7 @@ export class Orders extends BaseResource<IOrder> {
   public async getAll(opts?: object): Promise<IOrderPaginationResult> {
     const query = this.buildQueryStringFromParams(opts)
     const url = this.baseUrl + query
-    
+
     const response = await this.shipstation.request({
       url,
       method: RequestMethod.GET
@@ -45,4 +47,18 @@ export class Orders extends BaseResource<IOrder> {
 
     return response.data as ICreateOrUpdateOrderBulkResponse
   }
+
+  public async createLabel(
+    data: ICreateLabel
+  ): Promise<ICreateLabelResponse> {
+    const url = `${this.baseUrl}/createlabelfororder`
+    const response = await this.shipstation.request({
+      url,
+      method: RequestMethod.POST,
+      data
+    })
+
+    return response.data as ICreateLabelResponse
+  }
+
 }

--- a/typings/models/Order.d.ts
+++ b/typings/models/Order.d.ts
@@ -102,6 +102,19 @@ export interface IOrderItem {
     createDate: string;
     modifyDate: string;
 }
+export interface ICreateLabel {
+    orderId: number;
+    carrierCode?: string;
+    serviceCode?: string;
+    confirmation?: string;
+    shipDate: string;
+    weight?: IWeight;
+    dimensions?: IDimensions;
+    insuranceOptions?: IInsuranceOptions;
+    internationalOptions?: IInternationalOptions;
+    advancedOptions?: IAdvancedOptions;
+    testLabel: boolean;
+}
 export interface IItemOption {
     name: string;
     value: string;
@@ -119,5 +132,13 @@ interface IBulkCreateOrUpdateOrderResponse {
 export interface ICreateOrUpdateOrderBulkResponse {
     results: IBulkCreateOrUpdateOrderResponse[];
     hasErrors: boolean;
+}
+export interface ICreateLabelResponse {
+    shipmentId: number;
+    shipmentCost: number;
+    insuranceCost: number;
+    trackingNumber: string;
+    labelData: string;
+    formData?: string;
 }
 export {};

--- a/typings/resources/Orders.d.ts
+++ b/typings/resources/Orders.d.ts
@@ -1,4 +1,4 @@
-import { ICreateOrUpdateOrder, ICreateOrUpdateOrderBulkResponse, IOrder, IOrderPaginationResult } from '../models';
+import { ICreateOrUpdateOrder, ICreateOrUpdateOrderBulkResponse, IOrder, IOrderPaginationResult, ICreateLabel, ICreateLabelResponse } from '../models';
 import Shipstation from '../shipstation';
 import { BaseResource } from './Base';
 export declare class Orders extends BaseResource<IOrder> {
@@ -7,4 +7,5 @@ export declare class Orders extends BaseResource<IOrder> {
     getAll(opts?: object): Promise<IOrderPaginationResult>;
     createOrUpdate(data: ICreateOrUpdateOrder): Promise<IOrder>;
     createOrUpdateBulk(data: ICreateOrUpdateOrder[]): Promise<ICreateOrUpdateOrderBulkResponse>;
+    createLabel(data: ICreateLabel): Promise<ICreateLabelResponse>;
 }


### PR DESCRIPTION
DOCS: https://www.shipstation.com/docs/api/orders/create-label/

- Although the "ICreateLabel" model says "carrierCode", "serviceCode" and some other fields are required, but they can be preset using ShipStation rules. I left them as optional, since our store already presets those fields and we don't want them overwritten when making a call via the API.

- The "ICreateLabelResponse" model's last field "formData" has always been null and the docs doesn't show what type it is. I assumed it is type string.

- This is my first pull request ever so let me know if I should be doing something differently. :)