### PR TITLE
Allow credentials to be passed as options argument in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ const orders = await shipstation.orders.getAll()
 const order = await shipstation.orders.get(1244)
 ```
 
-- Optionaly, provide Shipstation credentials through the options
+- Optionaly, set Shipstation credentials through the options:
   - apiKey (your Shipstation API Key)
   - apiSecret (your Shipstation API secret)
 
 ```js
 const shipstation = new ShipStation({
-  apiKey: '0000000000000000aaaaaaaaaaaaaaaa',
-  apiSecret: '9999999999999999zzzzzzzzzzzzzzzz'
+  apiKey: '<key>',
+  apiSecret: '<secret>'
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,15 @@ const orders = await shipstation.orders.getAll()
 // Get order by id
 const order = await shipstation.orders.get(1244)
 ```
+
+- Optionaly, provide Shipstation credentials through the options
+  - apiKey (your Shipstation API Key)
+  - apiSecret (your Shipstation API secret)
+
+```js
+const shipstation = new ShipStation({
+  apiKey: '0000000000000000aaaaaaaaaaaaaaaa',
+  apiSecret: '9999999999999999zzzzzzzzzzzzzzzz'
+})
+```
+

--- a/dist/index.js
+++ b/dist/index.js
@@ -19,8 +19,8 @@ var Webhooks_1 = require("./resources/Webhooks");
 var shipstation_1 = __importStar(require("./shipstation"));
 exports.RequestMethod = shipstation_1.RequestMethod;
 var ShipStationAPI = (function () {
-    function ShipStationAPI() {
-        this.ss = new shipstation_1.default();
+    function ShipStationAPI(options) {
+        this.ss = new shipstation_1.default(options);
         this.orders = new Orders_1.Orders(this.ss);
         this.carriers = new Carriers_1.Carriers(this.ss);
         this.fulfillments = new Fulfillments_1.Fulfillments(this.ss);

--- a/dist/shipstation.js
+++ b/dist/shipstation.js
@@ -17,7 +17,7 @@ var RequestMethod;
     RequestMethod["DELETE"] = "DELETE";
 })(RequestMethod = exports.RequestMethod || (exports.RequestMethod = {}));
 var Shipstation = (function () {
-    function Shipstation() {
+    function Shipstation(options) {
         var _this = this;
         this.baseUrl = 'https://ssapi.shipstation.com/';
         this.request = function (_a) {
@@ -34,10 +34,13 @@ var Shipstation = (function () {
             }
             return axios_1.default.request(opts);
         };
-        if (!process.env.SS_API_KEY || !process.env.SS_API_SECRET) {
-            throw new Error("APIKey and API Secret are required! Provided API Key: " + process.env.SS_API_KEY + " API Secret: " + process.env.SS_API_SECRET);
+        var key = options && options.apiKey ? options.apiKey : process.env.SS_API_KEY;
+        var secret = options && options.apiSecret
+            ? options.apiSecret : process.env.SS_API_SECRET;
+        if (!key || !secret) {
+            throw new Error("APIKey and API Secret are required! Provided API Key: " + key + " API Secret: " + secret);
         }
-        this.authorizationToken = base64.encode(process.env.SS_API_KEY + ":" + process.env.SS_API_SECRET);
+        this.authorizationToken = base64.encode(key + ":" + secret);
         this.request = stopcock(this.request, rateLimitOpts);
     }
     return Shipstation;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ import { Shipments } from './resources/Shipments'
 import { Stores } from './resources/Stores'
 import { Warehouses } from './resources/Warehouses'
 import { Webhooks } from './resources/Webhooks'
-import Shipstation, { IShipstationRequestOptions, RequestMethod } from './shipstation'
+import Shipstation, {
+  IShipstationRequestOptions,
+  IShipstationOptions,
+  RequestMethod,
+} from './shipstation'
 
 export default class ShipStationAPI {
   private ss: Shipstation
@@ -24,8 +28,8 @@ export default class ShipStationAPI {
     args: IShipstationRequestOptions
   ) => Promise<AxiosResponse<any>>
 
-  constructor() {
-    this.ss = new Shipstation()
+  constructor(options?: IShipstationOptions) {
+    this.ss = new Shipstation(options)
 
     this.orders = new Orders(this.ss)
     this.carriers = new Carriers(this.ss)

--- a/src/shipstation.ts
+++ b/src/shipstation.ts
@@ -33,8 +33,11 @@ export default class Shipstation {
   private baseUrl: string = 'https://ssapi.shipstation.com/'
 
   constructor(options?: IShipstationOptions) {
-    const key = options?.apiKey || process.env.SS_API_KEY
-    const secret = options?.apiSecret || process.env.SS_API_SECRET
+    const key =
+      options && options.apiKey ? options.apiKey : process.env.SS_API_KEY
+    const secret =
+      options && options.apiSecret
+        ? options.apiSecret : process.env.SS_API_SECRET
 
     if (!key || !secret) {
       // tslint:disable-next-line:no-console

--- a/src/shipstation.ts
+++ b/src/shipstation.ts
@@ -23,20 +23,28 @@ export interface IShipstationRequestOptions {
   data?: any
 }
 
+export interface IShipstationOptions {
+  apiKey?: string
+  apiSecret?: string
+}
+
 export default class Shipstation {
   public authorizationToken: string
   private baseUrl: string = 'https://ssapi.shipstation.com/'
 
-  constructor() {
-    if (!process.env.SS_API_KEY || !process.env.SS_API_SECRET) {
+  constructor(options?: IShipstationOptions) {
+    const key = options?.apiKey || process.env.SS_API_KEY
+    const secret = options?.apiSecret || process.env.SS_API_SECRET
+
+    if (!key || !secret) {
       // tslint:disable-next-line:no-console
       throw new Error(
-        `APIKey and API Secret are required! Provided API Key: ${process.env.SS_API_KEY} API Secret: ${process.env.SS_API_SECRET}`
+        `APIKey and API Secret are required! Provided API Key: ${key} API Secret: ${secret}`
       )
     }
 
     this.authorizationToken = base64.encode(
-      `${process.env.SS_API_KEY}:${process.env.SS_API_SECRET}`
+      `${key}:${secret}`
     )
 
     // Globally define API ratelimiting

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,7 +7,7 @@ import { Shipments } from './resources/Shipments';
 import { Stores } from './resources/Stores';
 import { Warehouses } from './resources/Warehouses';
 import { Webhooks } from './resources/Webhooks';
-import { IShipstationRequestOptions, RequestMethod } from './shipstation';
+import { IShipstationRequestOptions, IShipstationOptions, RequestMethod } from './shipstation';
 export default class ShipStationAPI {
     private ss;
     orders: Orders;
@@ -18,6 +18,6 @@ export default class ShipStationAPI {
     warehouses: Warehouses;
     webhooks: Webhooks;
     request: (args: IShipstationRequestOptions) => Promise<AxiosResponse<any>>;
-    constructor();
+    constructor(options?: IShipstationOptions);
 }
 export { Models, IShipstationRequestOptions, RequestMethod };

--- a/typings/shipstation.d.ts
+++ b/typings/shipstation.d.ts
@@ -9,6 +9,10 @@ export interface IShipstationRequestOptions {
     useBaseUrl?: boolean;
     data?: any;
 }
+export interface IShipstationOptions {
+    apiKey?: string;
+    apiSecret?: string;
+}
 export default class Shipstation {
     authorizationToken: string;
     private baseUrl;

--- a/typings/shipstation.d.ts
+++ b/typings/shipstation.d.ts
@@ -16,6 +16,6 @@ export interface IShipstationOptions {
 export default class Shipstation {
     authorizationToken: string;
     private baseUrl;
-    constructor();
+    constructor(options?: IShipstationOptions);
     request: ({ url, method, useBaseUrl, data }: IShipstationRequestOptions) => Promise<import("axios").AxiosResponse<any>>;
 }


### PR DESCRIPTION
While consuming shipstation credentials from .env is a great idea, security wise, it makes it so all instances  are authenticated with a single shipstationAPI.

Giving the option to provide these credentials through the constructor opens the possibility of connection to different accounts concurrently (as i've needed to do), by simply creating multiple instances of the class.