### PR TITLE
Add support for retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ const shipstation = new ShipStation({
 })
 ```
 
+- Optinally, Retry Shipstation API failures via:
+    - Set retry `true` to enable default options
+    - OR provide an object with any options supported by [axios-retry](https://www.npmjs.com/package/axios-retry)
+
+```js
+const shipstation = new ShipStation({
+    // default retry config
+    retry: true,
+
+    // OR custom 
+    retry: { retries: 3 }
+})
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const orders = await shipstation.orders.getAll()
 const order = await shipstation.orders.get(1244)
 ```
 
-- Optionaly, set Shipstation credentials through the options:
+- Optionally, set Shipstation credentials through the options:
   - apiKey (your Shipstation API Key)
   - apiSecret (your Shipstation API secret)
 
@@ -34,7 +34,7 @@ const shipstation = new ShipStation({
 })
 ```
 
-- Optinally, Retry Shipstation API failures via:
+- Optionally, Retry Shipstation API failures via:
     - Set retry `true` to enable default options
     - OR provide an object with any options supported by [axios-retry](https://www.npmjs.com/package/axios-retry)
 

--- a/dist/shipstation.js
+++ b/dist/shipstation.js
@@ -4,6 +4,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 var axios_1 = __importDefault(require("axios"));
+var axios_retry_1 = __importDefault(require("axios-retry"));
 var base64 = require('base-64');
 var stopcock = require('stopcock');
 var rateLimitOpts = {
@@ -42,6 +43,9 @@ var Shipstation = (function () {
         }
         this.authorizationToken = base64.encode(key + ":" + secret);
         this.request = stopcock(this.request, rateLimitOpts);
+        if (options && options.retry) {
+            axios_retry_1.default(axios_1.default, typeof options.retry === 'boolean' ? undefined : options.retry);
+        }
     }
     return Shipstation;
 }());

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.11"
+      }
+    },
     "@types/axios": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
@@ -33,6 +41,15 @@
         "follow-redirects": "^1.14.0"
       }
     },
+    "axios-retry": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.5.0.tgz",
+      "integrity": "sha512-g48qNrLX30VU6ECWltpFCPegKK6dWzMDYv2o83W2zUL/Zh/SLXbT6ksGoKqYZHtghzqeeXhZBcSXJkO1fPbCcw==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      }
+    },
     "base-64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
@@ -55,6 +72,11 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
       "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
@@ -75,6 +97,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shipstation-node",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "unofficial node.js wrapper for the shipstation api",
   "main": "dist/index.js",
   "scripts": {
@@ -11,6 +11,7 @@
   "types": "typings/index.d.ts",
   "dependencies": {
     "axios": "^0.21.1",
+    "axios-retry": "^3.5.0",
     "base-64": "^0.1.0",
     "stopcock": "^1.0.0",
     "typescript": "^3.6.4"

--- a/src/shipstation.ts
+++ b/src/shipstation.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios'
+import axiosRetry, { IAxiosRetryConfig } from 'axios-retry'
 
 // tslint:disable-next-line:no-var-requires
 const base64 = require('base-64')
@@ -26,6 +27,7 @@ export interface IShipstationRequestOptions {
 export interface IShipstationOptions {
   apiKey?: string
   apiSecret?: string
+  retry?: IAxiosRetryConfig | boolean
 }
 
 export default class Shipstation {
@@ -47,11 +49,19 @@ export default class Shipstation {
     }
 
     this.authorizationToken = base64.encode(
-      `${key}:${secret}`
+        `${key}:${secret}`
     )
 
     // Globally define API ratelimiting
     this.request = stopcock(this.request, rateLimitOpts)
+
+    // Retry failed requests
+    if (options && options.retry) {
+      axiosRetry(
+        axios,
+        typeof options.retry === 'boolean' ? undefined : options.retry
+      )
+    }
   }
 
   public request = ({

--- a/typings/shipstation.d.ts
+++ b/typings/shipstation.d.ts
@@ -1,3 +1,4 @@
+import { IAxiosRetryConfig } from 'axios-retry';
 export declare enum RequestMethod {
     GET = "GET",
     POST = "POST",
@@ -12,6 +13,7 @@ export interface IShipstationRequestOptions {
 export interface IShipstationOptions {
     apiKey?: string;
     apiSecret?: string;
+    retry?: IAxiosRetryConfig | boolean;
 }
 export default class Shipstation {
     authorizationToken: string;


### PR DESCRIPTION
This PR adds support for retries:

- Disabled by default
- Quick-enable via default `axios-retry` config
- Custom setup via `AxiosRetryConfig`

My use case:

- I've been seeing 502s errors lately, I'll be adding a custom config to retry these in certain scenarios