### PR TITLE
Adding All Shipment Requests

### DIFF
--- a/src/models/CreateLabelOptions.ts
+++ b/src/models/CreateLabelOptions.ts
@@ -1,0 +1,23 @@
+import { IAddress } from "./Address";
+import { IAdvancedOptions } from "./AdvancedOptions";
+import { IDimensions } from "./Dimensions";
+import { IInsuranceOptions } from "./InsuranceOptions";
+import { IInternationalOptions } from "./InternationalOptions";
+import { DeliveryConfirmation } from "./ShippingRateOptions";
+import { IWeight } from "./Weight";
+
+export interface ICreateLabelOptions {
+    carrierCode: string;
+    packageCode: null | string;
+    serviceCode: null | string;
+    confirmation?: DeliveryConfirmation;
+    shipDate: string;
+    weight: IWeight;
+    dimensions?: IDimensions;
+    shipFrom: IAddress;
+    shopTo: IAddress;
+    insuranceOptions?: IInsuranceOptions;
+    internationalOptions?: IInternationalOptions;
+    advancedOptions?: IAdvancedOptions;
+    testLabel?: boolean;
+}

--- a/src/models/CreateLabelOptions.ts
+++ b/src/models/CreateLabelOptions.ts
@@ -15,7 +15,7 @@ export interface ICreateLabelOptions {
     weight: IWeight;
     dimensions?: IDimensions;
     shipFrom: IAddress;
-    shopTo: IAddress;
+    shipTo: IAddress;
     insuranceOptions?: IInsuranceOptions;
     internationalOptions?: IInternationalOptions;
     advancedOptions?: IAdvancedOptions;

--- a/src/models/VoidLabel.ts
+++ b/src/models/VoidLabel.ts
@@ -1,0 +1,8 @@
+export interface IVoidLabelOptions {
+    shipmentId: number;
+}
+
+export interface IVoidLabel {
+    approved: boolean;
+    message: string;
+}

--- a/src/resources/Shipments.ts
+++ b/src/resources/Shipments.ts
@@ -1,4 +1,5 @@
 import { IShipment, IShippingRate, IShippingRateOptions } from '../models'
+import { ICreateLabelOptions } from '../models/CreateLabelOptions'
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
 
@@ -27,5 +28,16 @@ export class Shipments extends BaseResource<IShipment> {
       data,
     })
     return response.data as IShippingRate[]
+  }
+
+  public async createLabel(data?: ICreateLabelOptions): Promise<IShipment> {
+    const url = this.baseUrl + '/createlabel'
+
+    const response = await this.shipstation.request({
+      url,
+      method: RequestMethod.POST,
+      data
+    })
+    return response.data as IShipment
   }
 }

--- a/src/resources/Shipments.ts
+++ b/src/resources/Shipments.ts
@@ -1,5 +1,6 @@
 import { IShipment, IShippingRate, IShippingRateOptions } from '../models'
 import { ICreateLabelOptions } from '../models/CreateLabelOptions'
+import { IVoidLabel, IVoidLabelOptions } from '../models/VoidLabel'
 import Shipstation, { RequestMethod } from '../shipstation'
 import { BaseResource } from './Base'
 
@@ -30,7 +31,7 @@ export class Shipments extends BaseResource<IShipment> {
     return response.data as IShippingRate[]
   }
 
-  public async createLabel(data?: ICreateLabelOptions): Promise<IShipment> {
+  public async createLabel(data: ICreateLabelOptions): Promise<IShipment> {
     const url = this.baseUrl + '/createlabel'
 
     const response = await this.shipstation.request({
@@ -39,5 +40,16 @@ export class Shipments extends BaseResource<IShipment> {
       data
     })
     return response.data as IShipment
+  }
+
+  public async voidLabel(data: IVoidLabelOptions): Promise<IVoidLabel> {
+    const url = this.baseUrl + '/voidlabel'
+
+    const response = await this.shipstation.request({
+      url,
+      method: RequestMethod.POST,
+      data
+    })
+    return response.data as IVoidLabel
   }
 }


### PR DESCRIPTION
Adding more of the available API requests provided by ShipStation to improve functionality coverage of this library.

createLabel endpoint takes its own request data and returns a new Shipment Object.

the createLabel and voidLabel functions were added as part of the `shipments` resource.

createLabelEndpoint: https://www.shipstation.com/docs/api/shipments/create-label/
voidLabelEndpoint: https://www.shipstation.com/docs/api/shipments/void-label/