### PR TITLE
Remove common get route

### DIFF
--- a/dist/resources/Base.js
+++ b/dist/resources/Base.js
@@ -1,25 +1,8 @@
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 export class BaseResource {
     constructor(shipstation, baseUrl) {
         this.shipstation = shipstation;
         this.baseUrl = baseUrl;
         this.shipstation = shipstation;
         this.baseUrl = baseUrl;
-    }
-    get(id) {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this.shipstation.request({
-                url: `${this.baseUrl}/${id}`,
-                method: 'GET'
-            });
-        });
     }
 }

--- a/dist/resources/Carriers.js
+++ b/dist/resources/Carriers.js
@@ -13,7 +13,15 @@ export class Carriers extends BaseResource {
         super(shipstation, 'carriers');
         this.shipstation = shipstation;
     }
-    getAll() {
+    get(carrierCode) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.shipstation.request({
+                url: `${this.baseUrl}?carrierCode=${carrierCode}`,
+                method: 'GET'
+            });
+        });
+    }
+    list() {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 url: this.baseUrl,

--- a/dist/resources/Fulfillments.js
+++ b/dist/resources/Fulfillments.js
@@ -13,7 +13,7 @@ export class Fulfillments extends BaseResource {
         super(shipstation, 'fulfillments');
         this.shipstation = shipstation;
     }
-    getAll(params) {
+    list(params) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 url: this.baseUrl,

--- a/dist/resources/Orders.js
+++ b/dist/resources/Orders.js
@@ -13,7 +13,15 @@ export class Orders extends BaseResource {
         super(shipstation, 'orders');
         this.shipstation = shipstation;
     }
-    getAll(params) {
+    get(orderId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.shipstation.request({
+                url: `${this.baseUrl}/${orderId}`,
+                method: 'GET'
+            });
+        });
+    }
+    list(params) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 url: this.baseUrl,
@@ -31,7 +39,7 @@ export class Orders extends BaseResource {
             });
         });
     }
-    createOrUpdateBulk(data) {
+    createOrUpdateMultiple(data) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 url: `${this.baseUrl}/createorders`,

--- a/dist/resources/Products.js
+++ b/dist/resources/Products.js
@@ -13,7 +13,15 @@ export class Products extends BaseResource {
         super(shipstation, 'products');
         this.shipstation = shipstation;
     }
-    getAll(params) {
+    get(productId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.shipstation.request({
+                url: `${this.baseUrl}/${productId}`,
+                method: 'GET'
+            });
+        });
+    }
+    list(params) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 url: this.baseUrl,

--- a/dist/resources/Shipments.js
+++ b/dist/resources/Shipments.js
@@ -13,7 +13,7 @@ export class Shipments extends BaseResource {
         super(shipstation, 'shipments');
         this.shipstation = shipstation;
     }
-    getAll(params) {
+    list(params) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 url: this.baseUrl,

--- a/dist/resources/Stores.js
+++ b/dist/resources/Stores.js
@@ -13,7 +13,15 @@ export class Stores extends BaseResource {
         super(shipstation, 'stores');
         this.shipstation = shipstation;
     }
-    getAll(params) {
+    get(storeId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.shipstation.request({
+                url: `${this.baseUrl}/${storeId}`,
+                method: 'GET'
+            });
+        });
+    }
+    list(params) {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 params,

--- a/dist/resources/Warehouses.js
+++ b/dist/resources/Warehouses.js
@@ -13,7 +13,15 @@ export class Warehouses extends BaseResource {
         super(shipstation, 'warehouses');
         this.shipstation = shipstation;
     }
-    getAll() {
+    get(warehouseId) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return this.shipstation.request({
+                url: `${this.baseUrl}/${warehouseId}`,
+                method: 'GET'
+            });
+        });
+    }
+    listWarehouses() {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 url: this.baseUrl,

--- a/dist/resources/Webhooks.js
+++ b/dist/resources/Webhooks.js
@@ -13,7 +13,7 @@ export class Webhooks extends BaseResource {
         super(shipstation, 'webhooks');
         this.shipstation = shipstation;
     }
-    getAll() {
+    list() {
         return __awaiter(this, void 0, void 0, function* () {
             return this.shipstation.request({
                 url: this.baseUrl,

--- a/package.json
+++ b/package.json
@@ -38,5 +38,5 @@
     "lint": "eslint --max-warnings 0 --config=eslint.config.js"
   },
   "types": "typings/index.d.ts",
-  "version": "0.26.0"
+  "version": "0.27.0"
 }

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -138,7 +138,7 @@ interface IBulkCreateOrUpdateOrderResponse {
   errorMessage: string | null;
 }
 
-export interface ICreateOrUpdateOrderBulkResponse {
+export interface ICreateOrUpdateMultipleOrdersResponse {
   results: Array<IBulkCreateOrUpdateOrderResponse>;
   hasErrors: boolean;
 }

--- a/src/resources/Base.ts
+++ b/src/resources/Base.ts
@@ -1,18 +1,11 @@
 import type Shipstation from '../shipstation';
 
-export abstract class BaseResource<T> {
+export abstract class BaseResource {
   constructor(
     protected shipstation: Shipstation,
     protected baseUrl: string
   ) {
     this.shipstation = shipstation;
     this.baseUrl = baseUrl;
-  }
-
-  public async get(id: number): Promise<T> {
-    return this.shipstation.request<T>({
-      url: `${this.baseUrl}/${id}`,
-      method: 'GET'
-    });
   }
 }

--- a/src/resources/Carriers.ts
+++ b/src/resources/Carriers.ts
@@ -2,12 +2,19 @@ import type { ICarrier } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
 
-export class Carriers extends BaseResource<ICarrier> {
+export class Carriers extends BaseResource {
   constructor(protected override shipstation: Shipstation) {
     super(shipstation, 'carriers');
   }
 
-  public async getAll(): Promise<Array<ICarrier>> {
+  public async get(carrierCode: string): Promise<ICarrier> {
+    return this.shipstation.request<ICarrier>({
+      url: `${this.baseUrl}?carrierCode=${carrierCode}`,
+      method: 'GET'
+    });
+  }
+
+  public async list(): Promise<Array<ICarrier>> {
     return this.shipstation.request<Array<ICarrier>>({
       url: this.baseUrl,
       method: 'GET'

--- a/src/resources/Fulfillments.ts
+++ b/src/resources/Fulfillments.ts
@@ -1,13 +1,13 @@
-import type { IFulfillment, IFulfillmentPaginationResult } from '../models';
+import type { IFulfillmentPaginationResult } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
 
-export class Fulfillments extends BaseResource<IFulfillment> {
+export class Fulfillments extends BaseResource {
   constructor(protected override shipstation: Shipstation) {
     super(shipstation, 'fulfillments');
   }
 
-  public async getAll(params?: object): Promise<IFulfillmentPaginationResult> {
+  public async list(params?: object): Promise<IFulfillmentPaginationResult> {
     return this.shipstation.request<IFulfillmentPaginationResult>({
       url: this.baseUrl,
       method: 'GET',

--- a/src/resources/Orders.ts
+++ b/src/resources/Orders.ts
@@ -1,6 +1,6 @@
 import type {
   ICreateOrUpdateOrder,
-  ICreateOrUpdateOrderBulkResponse,
+  ICreateOrUpdateMultipleOrdersResponse,
   IOrder,
   IOrderPaginationResult,
   ICreateLabel,
@@ -9,12 +9,19 @@ import type {
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
 
-export class Orders extends BaseResource<IOrder> {
+export class Orders extends BaseResource {
   constructor(protected override shipstation: Shipstation) {
     super(shipstation, 'orders');
   }
 
-  public async getAll(params?: object): Promise<IOrderPaginationResult> {
+  public async get(orderId: number): Promise<IOrder> {
+    return this.shipstation.request<IOrder>({
+      url: `${this.baseUrl}/${orderId}`,
+      method: 'GET'
+    });
+  }
+
+  public async list(params?: object): Promise<IOrderPaginationResult> {
     return this.shipstation.request<IOrderPaginationResult>({
       url: this.baseUrl,
       method: 'GET',
@@ -30,8 +37,10 @@ export class Orders extends BaseResource<IOrder> {
     });
   }
 
-  public async createOrUpdateBulk(data: Array<ICreateOrUpdateOrder>): Promise<ICreateOrUpdateOrderBulkResponse> {
-    return this.shipstation.request<ICreateOrUpdateOrderBulkResponse>({
+  public async createOrUpdateMultiple(
+    data: Array<ICreateOrUpdateOrder>
+  ): Promise<ICreateOrUpdateMultipleOrdersResponse> {
+    return this.shipstation.request<ICreateOrUpdateMultipleOrdersResponse>({
       url: `${this.baseUrl}/createorders`,
       method: 'POST',
       data

--- a/src/resources/Products.ts
+++ b/src/resources/Products.ts
@@ -2,9 +2,16 @@ import type { IProduct, IProductPaginationResult, IProductUpdateResponse } from 
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
 
-export class Products extends BaseResource<IProduct> {
+export class Products extends BaseResource {
   constructor(protected override shipstation: Shipstation) {
     super(shipstation, 'products');
+  }
+
+  public async get(productId: number): Promise<IProduct> {
+    return this.shipstation.request<IProduct>({
+      url: `${this.baseUrl}/${productId}`,
+      method: 'GET'
+    });
   }
 
   /**
@@ -13,7 +20,7 @@ export class Products extends BaseResource<IProduct> {
    * @returns {Promise<IProductPaginationResult>}
    * @see https://www.shipstation.com/docs/api/products/list/
    */
-  public async getAll(params?: object): Promise<IProductPaginationResult> {
+  public async list(params?: object): Promise<IProductPaginationResult> {
     return this.shipstation.request<IProductPaginationResult>({
       url: this.baseUrl,
       method: 'GET',

--- a/src/resources/Shipments.ts
+++ b/src/resources/Shipments.ts
@@ -4,12 +4,12 @@ import type { IVoidLabel, IVoidLabelOptions } from '../models/VoidLabel';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
 
-export class Shipments extends BaseResource<IShipment> {
+export class Shipments extends BaseResource {
   constructor(protected override shipstation: Shipstation) {
     super(shipstation, 'shipments');
   }
 
-  public async getAll(params?: object): Promise<Array<IShipment>> {
+  public async list(params?: object): Promise<Array<IShipment>> {
     return this.shipstation.request<Array<IShipment>>({
       url: this.baseUrl,
       method: 'GET',

--- a/src/resources/Stores.ts
+++ b/src/resources/Stores.ts
@@ -7,12 +7,19 @@ export interface IGetAllStoresOptions {
   marketplaceId?: number;
 }
 
-export class Stores extends BaseResource<IStore> {
+export class Stores extends BaseResource {
   constructor(protected override shipstation: Shipstation) {
     super(shipstation, 'stores');
   }
 
-  public async getAll(params?: IGetAllStoresOptions): Promise<Array<IStore>> {
+  public async get(storeId: number): Promise<IStore> {
+    return this.shipstation.request<IStore>({
+      url: `${this.baseUrl}/${storeId}`,
+      method: 'GET'
+    });
+  }
+
+  public async list(params?: IGetAllStoresOptions): Promise<Array<IStore>> {
     return this.shipstation.request<Array<IStore>>({
       params,
       url: this.baseUrl,

--- a/src/resources/Warehouses.ts
+++ b/src/resources/Warehouses.ts
@@ -2,12 +2,19 @@ import type { ICreateOrUpdateWarehouse, IUpdateOrDeleteWarehouseResponse, IWareh
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
 
-export class Warehouses extends BaseResource<IWarehouse> {
+export class Warehouses extends BaseResource {
   constructor(protected override shipstation: Shipstation) {
     super(shipstation, 'warehouses');
   }
 
-  public async getAll(): Promise<Array<IWarehouse>> {
+  public async get(warehouseId: number): Promise<IWarehouse> {
+    return this.shipstation.request<IWarehouse>({
+      url: `${this.baseUrl}/${warehouseId}`,
+      method: 'GET'
+    });
+  }
+
+  public async listWarehouses(): Promise<Array<IWarehouse>> {
     return this.shipstation.request<Array<IWarehouse>>({
       url: this.baseUrl,
       method: 'GET'

--- a/src/resources/Webhooks.ts
+++ b/src/resources/Webhooks.ts
@@ -1,13 +1,13 @@
-import type { ISubscribeToWebhookOpts, ISubscriptionResponse, IWebhook, IWebhookResult } from '../models';
+import type { ISubscribeToWebhookOpts, ISubscriptionResponse, IWebhookResult } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
 
-export class Webhooks extends BaseResource<IWebhook> {
+export class Webhooks extends BaseResource {
   constructor(protected override shipstation: Shipstation) {
     super(shipstation, 'webhooks');
   }
 
-  public async getAll(): Promise<IWebhookResult> {
+  public async list(): Promise<IWebhookResult> {
     return this.shipstation.request<IWebhookResult>({
       url: this.baseUrl,
       method: 'GET'

--- a/typings/models/Order.d.ts
+++ b/typings/models/Order.d.ts
@@ -129,7 +129,7 @@ interface IBulkCreateOrUpdateOrderResponse {
     success: boolean;
     errorMessage: string | null;
 }
-export interface ICreateOrUpdateOrderBulkResponse {
+export interface ICreateOrUpdateMultipleOrdersResponse {
     results: Array<IBulkCreateOrUpdateOrderResponse>;
     hasErrors: boolean;
 }

--- a/typings/resources/Base.d.ts
+++ b/typings/resources/Base.d.ts
@@ -1,7 +1,6 @@
 import type Shipstation from '../shipstation';
-export declare abstract class BaseResource<T> {
+export declare abstract class BaseResource {
     protected shipstation: Shipstation;
     protected baseUrl: string;
     constructor(shipstation: Shipstation, baseUrl: string);
-    get(id: number): Promise<T>;
 }

--- a/typings/resources/Carriers.d.ts
+++ b/typings/resources/Carriers.d.ts
@@ -1,8 +1,9 @@
 import type { ICarrier } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
-export declare class Carriers extends BaseResource<ICarrier> {
+export declare class Carriers extends BaseResource {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(): Promise<Array<ICarrier>>;
+    get(carrierCode: string): Promise<ICarrier>;
+    list(): Promise<Array<ICarrier>>;
 }

--- a/typings/resources/Fulfillments.d.ts
+++ b/typings/resources/Fulfillments.d.ts
@@ -1,8 +1,8 @@
-import type { IFulfillment, IFulfillmentPaginationResult } from '../models';
+import type { IFulfillmentPaginationResult } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
-export declare class Fulfillments extends BaseResource<IFulfillment> {
+export declare class Fulfillments extends BaseResource {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(params?: object): Promise<IFulfillmentPaginationResult>;
+    list(params?: object): Promise<IFulfillmentPaginationResult>;
 }

--- a/typings/resources/Orders.d.ts
+++ b/typings/resources/Orders.d.ts
@@ -1,11 +1,12 @@
-import type { ICreateOrUpdateOrder, ICreateOrUpdateOrderBulkResponse, IOrder, IOrderPaginationResult, ICreateLabel, ICreateLabelResponse } from '../models';
+import type { ICreateOrUpdateOrder, ICreateOrUpdateMultipleOrdersResponse, IOrder, IOrderPaginationResult, ICreateLabel, ICreateLabelResponse } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
-export declare class Orders extends BaseResource<IOrder> {
+export declare class Orders extends BaseResource {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(params?: object): Promise<IOrderPaginationResult>;
+    get(orderId: number): Promise<IOrder>;
+    list(params?: object): Promise<IOrderPaginationResult>;
     createOrUpdate(data: ICreateOrUpdateOrder): Promise<IOrder>;
-    createOrUpdateBulk(data: Array<ICreateOrUpdateOrder>): Promise<ICreateOrUpdateOrderBulkResponse>;
+    createOrUpdateMultiple(data: Array<ICreateOrUpdateOrder>): Promise<ICreateOrUpdateMultipleOrdersResponse>;
     createLabel(data: ICreateLabel): Promise<ICreateLabelResponse>;
 }

--- a/typings/resources/Products.d.ts
+++ b/typings/resources/Products.d.ts
@@ -1,9 +1,10 @@
 import type { IProduct, IProductPaginationResult, IProductUpdateResponse } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
-export declare class Products extends BaseResource<IProduct> {
+export declare class Products extends BaseResource {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(params?: object): Promise<IProductPaginationResult>;
+    get(productId: number): Promise<IProduct>;
+    list(params?: object): Promise<IProductPaginationResult>;
     update(data: IProduct): Promise<IProductUpdateResponse>;
 }

--- a/typings/resources/Shipments.d.ts
+++ b/typings/resources/Shipments.d.ts
@@ -3,10 +3,10 @@ import type { ICreateLabelOptions } from '../models/CreateLabelOptions';
 import type { IVoidLabel, IVoidLabelOptions } from '../models/VoidLabel';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
-export declare class Shipments extends BaseResource<IShipment> {
+export declare class Shipments extends BaseResource {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(params?: object): Promise<Array<IShipment>>;
+    list(params?: object): Promise<Array<IShipment>>;
     getRates(data?: IShippingRateOptions): Promise<Array<IShippingRate>>;
     createLabel(data: ICreateLabelOptions): Promise<IShipment>;
     voidLabel(data: IVoidLabelOptions): Promise<IVoidLabel>;

--- a/typings/resources/Stores.d.ts
+++ b/typings/resources/Stores.d.ts
@@ -5,8 +5,9 @@ export interface IGetAllStoresOptions {
     showInactive?: boolean;
     marketplaceId?: number;
 }
-export declare class Stores extends BaseResource<IStore> {
+export declare class Stores extends BaseResource {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(params?: IGetAllStoresOptions): Promise<Array<IStore>>;
+    get(storeId: number): Promise<IStore>;
+    list(params?: IGetAllStoresOptions): Promise<Array<IStore>>;
 }

--- a/typings/resources/Warehouses.d.ts
+++ b/typings/resources/Warehouses.d.ts
@@ -1,10 +1,11 @@
 import type { ICreateOrUpdateWarehouse, IUpdateOrDeleteWarehouseResponse, IWarehouse } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
-export declare class Warehouses extends BaseResource<IWarehouse> {
+export declare class Warehouses extends BaseResource {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(): Promise<Array<IWarehouse>>;
+    get(warehouseId: number): Promise<IWarehouse>;
+    listWarehouses(): Promise<Array<IWarehouse>>;
     create(data: ICreateOrUpdateWarehouse): Promise<IWarehouse>;
     update(id: number, data: ICreateOrUpdateWarehouse): Promise<IUpdateOrDeleteWarehouseResponse>;
     delete(id: number): Promise<IUpdateOrDeleteWarehouseResponse>;

--- a/typings/resources/Webhooks.d.ts
+++ b/typings/resources/Webhooks.d.ts
@@ -1,10 +1,10 @@
-import type { ISubscribeToWebhookOpts, ISubscriptionResponse, IWebhook, IWebhookResult } from '../models';
+import type { ISubscribeToWebhookOpts, ISubscriptionResponse, IWebhookResult } from '../models';
 import type Shipstation from '../shipstation';
 import { BaseResource } from './Base';
-export declare class Webhooks extends BaseResource<IWebhook> {
+export declare class Webhooks extends BaseResource {
     protected shipstation: Shipstation;
     constructor(shipstation: Shipstation);
-    getAll(): Promise<IWebhookResult>;
+    list(): Promise<IWebhookResult>;
     subscribe(data: ISubscribeToWebhookOpts): Promise<ISubscriptionResponse>;
     unsubscribe(id: number): Promise<null>;
 }


### PR DESCRIPTION
**THIS PR INTRODUCES BREAKING CHANGES**

* Removes the common `get` route applied to all resources, since not all have the `get` route
* Renames routes to match naming convention from API docs

Resolves https://github.com/kjaenicke/shipstation-node/issues/29